### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These are known feature requests to add Docker Swarm support to existing CSI plu
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | DigitalOcean CSI                    | [digitalocean/csi-digitalocean#57](https://github.com/digitalocean/csi-digitalocean/issues/57)               |
 | Hetzner Cloud CSI                   | [hetznercloud/csi-driver#374](https://github.com/hetznercloud/csi-driver/issues/374)                         |
+| Kadalu                              | [kadalu/kadalu#963](https://github.com/kadalu/kadalu/issues/963)                                             |
 | NetApp Trident CSI                  | [NetApp/trident#804](https://github.com/NetApp/trident/issues/804)                                           |
 | NFS CSI                             | [kubernetes-csi/csi-driver-nfs#/40](https://github.com/kubernetes-csi/csi-driver-nfs/issues/408)             |
 | Nutanix CSI                         | [nutanix/helm#/92](https://github.com/nutanix/helm/issues/92)                                                |


### PR DESCRIPTION
kaDalu is a project that can host or front a glusterfs compatible cluster for containerised loads and maintains a CSI driver for K8s, OpenShift and Nomad in this project.