### PR TITLE
Added option to append platform to version

### DIFF
--- a/csi-digitalocean/build.sh
+++ b/csi-digitalocean/build.sh
@@ -9,12 +9,13 @@ fi
 
 ORG=$1
 VERSION=$2
+VERSION_PLATFORM=$2${PLUGIN_PLATFORM:+"-$PLUGIN_PLATFORM"}
 
 rm -rf rootfs
 docker plugin disable csi-digitalocean:latest
 docker plugin rm csi-digitalocean:latest
-docker plugin disable $ORG/swarm-csi-digitalocean:v$VERSION
-docker plugin rm $ORG/swarm-csi-digitalocean:v$VERSION
+docker plugin disable $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
 docker rm -vf rootfsimage
 
 docker create --name rootfsimage docker.io/digitalocean/do-csi-plugin:v$VERSION
@@ -23,14 +24,14 @@ docker export rootfsimage | tar -x -C rootfs
 docker rm -vf rootfsimage
 cp entrypoint.sh rootfs/
 
-docker plugin create $ORG/swarm-csi-digitalocean:v$VERSION .
-docker plugin enable $ORG/swarm-csi-digitalocean:v$VERSION
-docker plugin push $ORG/swarm-csi-digitalocean:v$VERSION
-docker plugin disable $ORG/swarm-csi-digitalocean:v$VERSION
-docker plugin rm $ORG/swarm-csi-digitalocean:v$VERSION
+docker plugin create $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM .
+docker plugin enable $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
+docker plugin push $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
+docker plugin disable $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM
 docker plugin install \
     --alias csi-digitalocean \
     --grant-all-permissions \
-    $ORG/swarm-csi-digitalocean:v$VERSION \
+    $ORG/swarm-csi-digitalocean:v$VERSION_PLATFORM \
     DIGITALOCEAN_API_URL=$3 \
     DIGITALOCEAN_ACCESS_TOKEN=$4

--- a/csi-driver-aws-ebs/build.sh
+++ b/csi-driver-aws-ebs/build.sh
@@ -11,12 +11,13 @@ ORG=$1
 # 1.34.0 known to work
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 VERSION=$2
+VERSION_PLATFORM=$2${PLUGIN_PLATFORM:+"-$PLUGIN_PLATFORM"}
 
 rm -rf rootfs
 docker plugin disable csi-aws-ebs:latest
 docker plugin rm csi-aws-ebs:latest
-docker plugin disable $ORG/swarm-csi-aws-ebs:v$VERSION
-docker plugin rm $ORG/swarm-csi-aws-ebs:v$VERSION
+docker plugin disable $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
 docker rm -vf rootfsimage
 
 docker create --name rootfsimage public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v$VERSION
@@ -24,9 +25,9 @@ mkdir -p rootfs
 docker export rootfsimage | tar -x -C rootfs
 docker rm -vf rootfsimage
 
-docker plugin create $ORG/swarm-csi-aws-ebs:v$VERSION .
-docker plugin enable $ORG/swarm-csi-aws-ebs:v$VERSION
-docker plugin push $ORG/swarm-csi-aws-ebs:v$VERSION
-docker plugin disable $ORG/swarm-csi-aws-ebs:v$VERSION
-docker plugin rm $ORG/swarm-csi-aws-ebs:v$VERSION
-docker plugin install --alias ecs-aws-ebs --grant-all-permissions $ORG/swarm-csi-aws-ebs:v$VERSION
+docker plugin create $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM .
+docker plugin enable $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
+docker plugin push $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
+docker plugin disable $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM
+docker plugin install --alias ecs-aws-ebs --grant-all-permissions $ORG/swarm-csi-aws-ebs:v$VERSION_PLATFORM

--- a/csi-driver-nfs/build.sh
+++ b/csi-driver-nfs/build.sh
@@ -9,12 +9,13 @@ fi
 
 ORG=$1
 VERSION=$2
+VERSION_PLATFORM=$2${PLUGIN_PLATFORM:+"-$PLUGIN_PLATFORM"}
 
 rm -rf rootfs
 docker plugin disable csi-nfs:latest
 docker plugin rm csi-nfs:latest
-docker plugin disable $ORG/swarm-csi-nfs:v$VERSION
-docker plugin rm $ORG/swarm-csi-nfs:v$VERSION
+docker plugin disable $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
 docker rm -vf rootfsimage
 
 docker create --name rootfsimage registry.k8s.io/sig-storage/nfsplugin:v$VERSION
@@ -23,9 +24,9 @@ docker export rootfsimage | tar -x -C rootfs
 docker rm -vf rootfsimage
 cp entrypoint.sh rootfs/
 
-docker plugin create $ORG/swarm-csi-nfs:v$VERSION .
-docker plugin enable $ORG/swarm-csi-nfs:v$VERSION
-docker plugin push $ORG/swarm-csi-nfs:v$VERSION
-docker plugin disable $ORG/swarm-csi-nfs:v$VERSION
-docker plugin rm $ORG/swarm-csi-nfs:v$VERSION
-docker plugin install --alias csi-nfs --grant-all-permissions $ORG/swarm-csi-nfs:v$VERSION
+docker plugin create $ORG/swarm-csi-nfs:v$VERSION_PLATFORM .
+docker plugin enable $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
+docker plugin push $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
+docker plugin disable $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-nfs:v$VERSION_PLATFORM
+docker plugin install --alias csi-nfs --grant-all-permissions $ORG/swarm-csi-nfs:v$VERSION_PLATFORM

--- a/csi-driver-smb/build.sh
+++ b/csi-driver-smb/build.sh
@@ -9,23 +9,24 @@ fi
 
 ORG=$1
 VERSION=$2
+VERSION_PLATFORM=$2${PLUGIN_PLATFORM:+"-$PLUGIN_PLATFORM"}
 
 rm -rf rootfs
 docker plugin disable csi-smb:latest
 docker plugin rm csi-smb:latest
-docker plugin disable $ORG/swarm-csi-smb:v$VERSION
-docker plugin rm $ORG/swarm-csi-smb:v$VERSION
+docker plugin disable $ORG/swarm-csi-smb:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-smb:v$VERSION_PLATFORM
 docker rm -vf rootfsimage
 
-docker create --name rootfsimage registry.k8s.io/sig-storage/smbplugin:v$VERSION
+docker create --name rootfsimage registry.k8s.io/sig-storage/smbplugin:v$VERSION_PLATFORM
 mkdir -p rootfs
 docker export rootfsimage | tar -x -C rootfs
 docker rm -vf rootfsimage
 cp entrypoint.sh rootfs/
 
-docker plugin create $ORG/swarm-csi-smb:v$VERSION .
-docker plugin enable $ORG/swarm-csi-smb:v$VERSION
-docker plugin push $ORG/swarm-csi-smb:v$VERSION
-docker plugin disable $ORG/swarm-csi-smb:v$VERSION
-docker plugin rm $ORG/swarm-csi-smb:v$VERSION
-docker plugin install --alias csi-smb --grant-all-permissions $ORG/swarm-csi-smb:v$VERSION
+docker plugin create $ORG/swarm-csi-smb:v$VERSION_PLATFORM .
+docker plugin enable $ORG/swarm-csi-smb:v$VERSION_PLATFORM
+docker plugin push $ORG/swarm-csi-smb:v$VERSION_PLATFORM
+docker plugin disable $ORG/swarm-csi-smb:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-smb:v$VERSION_PLATFORM
+docker plugin install --alias csi-smb --grant-all-permissions $ORG/swarm-csi-smb:v$VERSION_PLATFORM

--- a/democratic-csi/local-hostpath/build.sh
+++ b/democratic-csi/local-hostpath/build.sh
@@ -9,12 +9,13 @@ fi
 
 ORG=$1
 VERSION=$2
+VERSION_PLATFORM=$2${PLUGIN_PLATFORM:+"-$PLUGIN_PLATFORM"}
 
 rm -rf rootfs
 docker plugin disable csi-local-path:latest
 docker plugin rm csi-local-path:latest
-docker plugin disable $ORG/swarm-csi-local-path:v$VERSION
-docker plugin rm $ORG/swarm-csi-local-path:v$VERSION
+docker plugin disable $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
 docker rm -vf rootfsimage
 
 docker create --name rootfsimage docker.io/democraticcsi/democratic-csi:v$VERSION
@@ -25,9 +26,9 @@ mkdir -p rootfs/home/csi/app/config
 cp entrypoint.sh rootfs/home/csi/app/
 cp local-hostpath.yaml rootfs/home/csi/app/config/
 
-docker plugin create $ORG/swarm-csi-local-path:v$VERSION .
-docker plugin enable $ORG/swarm-csi-local-path:v$VERSION
-docker plugin push $ORG/swarm-csi-local-path:v$VERSION
-docker plugin disable $ORG/swarm-csi-local-path:v$VERSION
-docker plugin rm $ORG/swarm-csi-local-path:v$VERSION
-docker plugin install --alias csi-local-path --grant-all-permissions $ORG/swarm-csi-local-path:v$VERSION
+docker plugin create $ORG/swarm-csi-local-path:v$VERSION_PLATFORM .
+docker plugin enable $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
+docker plugin push $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
+docker plugin disable $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
+docker plugin rm $ORG/swarm-csi-local-path:v$VERSION_PLATFORM
+docker plugin install --alias csi-local-path --grant-all-permissions $ORG/swarm-csi-local-path:v$VERSION_PLATFORM


### PR DESCRIPTION
Lately I wanted to extend the usage of my raspberry pi and thought it was a nice idea to host my docker volumes on a usb-stick mounted under a cifs share.  

Unfortunately I encountered an issue regarding dockers plugin handling.  
It seems like plugins can not be build independend of the architecture of the running docker instance, so since my plugin was created on a amd64 architecture I could not install it due to it complaining about missing the .sock file.
I created two VMs via qemu with different architectures (amd64 and aarch64) and tested if the debug.sh scripts were running correctly locally.  

As it turns out they do without any complaints. This got me thinking if appending an optional platform string was a nice workaround to support different architectures.  
Basically the user now has a choice of including the ENV variable 'PLUGIN_PLATFORM' when executing the build.sh script like so:

```
PLUGIN_PLATFORM=<any string> ./build.sh <org> <version>
```

If the ENV variable is not set the script resumes default operation.

Tested this version locally with no errors